### PR TITLE
doc: Add OpenOCD SWD information

### DIFF
--- a/doc/content/getting-started/programming-software/st-examples/_index.md
+++ b/doc/content/getting-started/programming-software/st-examples/_index.md
@@ -5,4 +5,4 @@ weight: -1
 distributions: null
 ---
 
-Different developers will use different developing tools, hence we provide multiple setup guides for different tools so you can use the one that best fits your preferences.
+Different developers will use different developing tools, hence we provide multiple setup guides for different tools so you can use the one that best fits your preferences. Note that for all options, the {{% gnse %}} needs to be powered, which is not necessarily done by the programmer.

--- a/doc/content/getting-started/programming-software/st-examples/openocd/_index.md
+++ b/doc/content/getting-started/programming-software/st-examples/openocd/_index.md
@@ -1,0 +1,29 @@
+---
+title: "OpenOCD"
+description: ""
+weight: 3
+distributions: null
+---
+
+[OpenOCD](http://openocd.org/) is commonly used for on-chip debugging, but can also be used to easily program executables via CLI.
+
+<!--more-->
+
+## Steps to reproduce
+
+To program a binary executable, run the following command in your terminal:
+
+```bash
+openocd -f interface/stlink.cfg -f target/stm32wlx.cfg -c "program <binary-file-location> verify reset exit 0x08000000"
+```
+Some parts of the command above are optional:
+- `verify` is used to verify the loaded firmware after programming;
+- `reset` will start the programmed executable without having to power cycle the device;
+- `exit` quits OpenOCD as it will otherwise keep running to debug the chip.
+
+`0x08000000` signifies the starting address of the user program. If you do not wish to input this, you can also opt to program the **elf** file (with the **.elf** filename extension) using the following command:
+
+```bash
+openocd -f interface/stlink.cfg -f target/stm32wlx.cfg -c "program <elf-file-location> verify reset exit"
+```
+The binary file is extracted from this file during compilation of the Generic Node firmware, so it should not make a difference which file you use.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Documentation was added for programming with OpenOCD. Closes #28.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added OpenOCD example commands with explanation.
- Small disclaimer that the GNSE should be powered when programmed.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

OpenOCD added STM32WL support not too long ago, see [this](http://openocd.org/2021/03/openocd-0-11-0-released/). If you're testing if it works, then you should also make sure that OpenOCD has the stm32wlx.cfg file.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
