### PR TITLE
Issue/fix gh pages

### DIFF
--- a/.hooks/install-hooks.go
+++ b/.hooks/install-hooks.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func installHook(name string) (err error) {
+	fmt.Printf("Installing %s hook\n", name)
+	f, err := os.OpenFile(filepath.Join(".git", "hooks", name), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+	_, err = fmt.Fprintf(f, "HOOK=\"%s\" ARGS=\"$@\" go run %s\n", name, filepath.Join(".hooks", "run-hooks.go"));
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var gitHooks = []string{"commit-msg"}
+
+// InstallHooks installs git hooks that help developers follow our best practices.
+func InstallHooks() error {
+	for _, hook := range gitHooks {
+		if err := installHook(hook); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func main() {
+	if err := InstallHooks(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/.hooks/run-hooks.go
+++ b/.hooks/run-hooks.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var gitCommitPrefixes = []string{
+	"doc",
+	"util",
+}
+
+func commitMsg(messageFile string) error {
+	fmt.Println("Running commit-msg hook")
+	if messageFile == "" {
+		messageFile = ".git/COMMIT_EDITMSG"
+	}
+	f, err := os.Open(messageFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	s.Scan()
+	commitMsg := s.Text()
+
+	if commitMsg == "" {
+		return errors.New("commit message must not be empty")
+	}
+
+	if strings.HasPrefix(commitMsg, "fixup! ") || strings.HasPrefix(commitMsg, "Merge ") {
+		return nil
+	}
+
+	// Check length:
+	switch {
+	case len(commitMsg) > 72:
+		return errors.New("commit message must be shorter than 72 characters")
+	case len(commitMsg) > 50:
+		// TODO: Warn.
+	}
+
+	// Check topics: Message structure:
+	split := strings.SplitN(commitMsg, ": ", 2)
+	if len(split) != 2 {
+		return fmt.Errorf("commit message must contain topics from %s",
+			strings.Join(gitCommitPrefixes, ","))
+	}
+
+	// Check topics:
+	topics := strings.Split(split[0], ",")
+	var unknownTopics []string
+nextTopic:
+	for _, topic := range topics {
+		for _, allowed := range gitCommitPrefixes {
+			if strings.TrimSpace(topic) == allowed {
+				continue nextTopic
+			}
+		}
+		unknownTopics = append(unknownTopics, topic)
+	}
+	if len(unknownTopics) > 0 {
+		return fmt.Errorf("commit messages must only topics from %s (and not %s)",
+			strings.Join(gitCommitPrefixes, ","),
+			strings.Join(unknownTopics, ","))
+	}
+
+	words := strings.Fields(split[1])
+
+	// Casing:
+	if words[0][0] < 'A' || words[0][0] > 'Z' {
+		return fmt.Errorf("commit messages must start with a capital letter (and %s doesn't)", words[0])
+	}
+
+	// Punctuation:
+	if strings.HasSuffix(commitMsg, ".") {
+		return fmt.Errorf("commit messages must not end with punctuation")
+	}
+
+	// Imperative
+	if strings.HasSuffix(words[0], "ed") || strings.HasSuffix(words[0], "ing") {
+		// TODO: Warn that Commit messages should use imperative mood
+	}
+
+	return nil
+}
+
+// RunHook runs the Git hook for $HOOK, arguments are taken from $ARGS.
+func RunHook() error {
+	hook, args := os.Getenv("HOOK"), strings.Fields(os.Getenv("ARGS"))
+	switch hook {
+	case "pre-commit":
+		fmt.Println("Running pre-commit hook with", args)
+		return nil
+	case "commit-msg":
+		var messageFile string
+		if len(args) > 0 {
+			messageFile = args[0]
+		}
+		return commitMsg(messageFile)
+	case "pre-push":
+		fmt.Println("Running pre-push hook with", args)
+		return nil
+	default:
+		return fmt.Errorf("Unknown hook %s", hook)
+	}
+}
+
+func main() {
+	if err := RunHook(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
#### Summary
Adding `.hooks` because of process described here https://discuss.thethingsindustries.com/t/deploying-generic-node-documentation-updates/930. `.hooks` folder is lacking on the `gh-pages` branch, so when we checkout a new branch from `gh-pages` and make some changes there, an error pops out making us unable to commit those changes. When this folder is not lacking, everything goes smoothly.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
